### PR TITLE
fix: skip weekends now correctly clamps midnight

### DIFF
--- a/src/discontinuity/skipWeekends.js
+++ b/src/discontinuity/skipWeekends.js
@@ -1,6 +1,14 @@
 import {timeDay, timeSaturday, timeMonday} from 'd3-time';
 
 export default function() {
+
+    // the indices returned by date.getDay()
+    const day = {
+        sunday: 0,
+        monday: 1,
+        saturday: 6
+    };
+
     const millisPerDay = 24 * 3600 * 1000;
     const millisPerWorkWeek = millisPerDay * 5;
     const millisPerWeek = millisPerDay * 7;
@@ -12,11 +20,16 @@ export default function() {
 
     skipWeekends.clampDown = (date) => {
         if (date && isWeekend(date)) {
-            const daysToSubtract = date.getDay() === 0 ? 2 : 1;
             // round the date up to midnight
             const newDate = timeDay.ceil(date);
             // then subtract the required number of days
-            return timeDay.offset(newDate, -daysToSubtract);
+            if (newDate.getDay() === day.sunday) {
+                return timeDay.offset(newDate, -1);
+            } else if (newDate.getDay() === day.monday) {
+                return timeDay.offset(newDate, -2);
+            } else {
+                return newDate;
+            }
         } else {
             return date;
         }
@@ -24,11 +37,16 @@ export default function() {
 
     skipWeekends.clampUp = (date) => {
         if (date && isWeekend(date)) {
-            const daysToAdd = date.getDay() === 0 ? 1 : 2;
             // round the date down to midnight
             const newDate = timeDay.floor(date);
             // then add the required number of days
-            return timeDay.offset(newDate, daysToAdd);
+            if (newDate.getDay() === day.saturday) {
+                return timeDay.offset(newDate, 2);
+            } else if (newDate.getDay() === day.sunday) {
+                return timeDay.offset(newDate, 1);
+            } else {
+                return newDate;
+            }
         } else {
             return date;
         }

--- a/test/discontinuity/skipWeekendsSpec.js
+++ b/test/discontinuity/skipWeekendsSpec.js
@@ -1,13 +1,14 @@
 import skipWeekends from '../../src/discontinuity/skipWeekends';
+import {timeDay, timeMillisecond, timeMinute} from 'd3-time';
 
 describe('skipWeekends', () => {
-
     const millisPerDay = 24 * 3600 * 1000;
-    const friday = new Date(2016, 0, 1);
-    const saturday = new Date(2016, 0, 2);
-    const sunday = new Date(2016, 0, 3);
-    const monday = new Date(2016, 0, 4);
     const wednesday = new Date(2016, 0, 6);
+
+    // this is 00:00:00 hours on monday, which is at the very start of the week
+    const mondayBoundary = new Date(2016, 0, 4);
+    // this is 00:00:00 hours on Saturday, which is at the very start of the weekend
+    const saturdayBoundary = new Date(2016, 0, 2);
 
     describe('clampUp', () => {
         it('should do nothing if provided with a weekday', () => {
@@ -15,12 +16,32 @@ describe('skipWeekends', () => {
         });
 
         it('should clamp up if given a weekend', () => {
-            expect(skipWeekends().clampUp(saturday)).toEqual(monday);
-            expect(skipWeekends().clampUp(sunday)).toEqual(monday);
+            // try subtracting a millisecond
+            expect(skipWeekends().clampUp(timeMillisecond.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting a minute
+            expect(skipWeekends().clampUp(timeMinute.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting a day
+            expect(skipWeekends().clampUp(timeDay.offset(mondayBoundary, -1)))
+              .toEqual(mondayBoundary);
+
+            // try subtracting one and a half days
+            expect(skipWeekends().clampUp(timeDay.offset(mondayBoundary, -1.5)))
+              .toEqual(mondayBoundary);
         });
 
         it('should not clamp up at the boundary of a discontinuity', () => {
-            expect(skipWeekends().clampUp(monday)).toEqual(monday);
+            // clamping the boundary should return the bundary
+            expect(skipWeekends().clampUp(mondayBoundary))
+              .toEqual(mondayBoundary);
+
+            // by subtracting one day and one millisecond, this will fall just outside of the weekend, so should not be clamped
+            const friday = timeMillisecond.offset(timeDay.offset(mondayBoundary, -2), -1);
+            expect(skipWeekends().clampUp(friday))
+              .toEqual(friday);
         });
     });
 
@@ -30,18 +51,44 @@ describe('skipWeekends', () => {
         });
 
         it('should clamp down if given a weekend', () => {
-            expect(skipWeekends().clampDown(saturday)).toEqual(friday);
-            expect(skipWeekends().clampDown(sunday)).toEqual(friday);
+            // clamping the boundary should return the bundary
+            expect(skipWeekends().clampDown(saturdayBoundary))
+              .toEqual(saturdayBoundary);
+
+            // try adding a millisecond
+            expect(skipWeekends().clampDown(timeMillisecond.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding a minute
+            expect(skipWeekends().clampDown(timeMinute.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding a day
+            expect(skipWeekends().clampDown(timeDay.offset(saturdayBoundary, 1)))
+              .toEqual(saturdayBoundary);
+
+            // try adding one and a half days
+            expect(skipWeekends().clampDown(timeDay.offset(saturdayBoundary, 1.5)))
+              .toEqual(saturdayBoundary);
+
         });
 
         it('should not clamp down at the boundary of a discontinuity', () => {
-            expect(skipWeekends().clampDown(friday)).toEqual(friday);
+            // by adding two days, this will fall just outside of the weekend, so should not be clamped
+            const monday = timeDay.offset(saturdayBoundary, 2);
+            expect(skipWeekends().clampDown(monday))
+              .toEqual(monday);
+
+            // by subtracting one millisecond, this will fall just outside of the weekend, so should not be clamped
+            const friday = timeMillisecond.offset(saturdayBoundary, -1);
+            expect(skipWeekends().clampDown(friday))
+              .toEqual(friday);
         });
     });
 
     it('should remove weekends', () => {
-        expect(skipWeekends().distance(monday, wednesday)).toEqual(2 * millisPerDay);
-        expect(skipWeekends().distance(monday, new Date(monday.getTime() + 7 * millisPerDay)))
+        expect(skipWeekends().distance(mondayBoundary, wednesday)).toEqual(2 * millisPerDay);
+        expect(skipWeekends().distance(mondayBoundary, timeDay.offset(mondayBoundary, 7)))
             .toEqual(5 * millisPerDay);
     });
 });


### PR DESCRIPTION
fixes #24 

The previous tests were incorrectly testing the boundaries, using Friday 00:00:00 as a boundary value, rather than Saturday 00:00:00.